### PR TITLE
Keyboard hides part of the form

### DIFF
--- a/Sources/WishKit/SwiftUI/CreateWishView.swift
+++ b/Sources/WishKit/SwiftUI/CreateWishView.swift
@@ -192,7 +192,7 @@ struct CreateWishView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(backgroundColor)
-        .ignoresSafeArea(edges: [.leading, .bottom, .trailing])
+        .ignoresSafeArea(edges: [.leading, .trailing])
     }
 
     private func handleTitleAndDescriptionChange() {

--- a/Sources/WishKit/SwiftUI/CreateWishView.swift
+++ b/Sources/WishKit/SwiftUI/CreateWishView.swift
@@ -192,7 +192,7 @@ struct CreateWishView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(backgroundColor)
-        .ignoresSafeArea(edges: [.leading, .trailing])
+        .ignoresSafeArea(.container, edges: [.leading, .bottom, .trailing])
     }
 
     private func handleTitleAndDescriptionChange() {


### PR DESCRIPTION
[IOS-4493](https://digitalmasterpieces.atlassian.net/browse/IOS-4493?atlOrigin=eyJpIjoiNjBkY2Q2ZTQ5ZTQzNGY5NjkwZDhjMDEyMzUyYTYwMDUiLCJwIjoiaiJ9)

Removed ignoreSafeAre .bottom from the submission form, so the submission button does not disappear behind the keyboard